### PR TITLE
Add Concierge section to homepage (content not final)

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -14,13 +14,13 @@ layout: default
           {{ section.content_md | markdownify }}
         </div>
       </div>
-      
+
       {% case section.name %}
         {% when "hero" %}
           <div class="hero-capabilities">
             <div class="row">
               <div class="col-sm-12 col-md-10 col-md-offset-1">
-                
+
                 <div class="visible-xs-block visible-sm-block">
                   <div class="row">
                     {% assign sorted_services = section.capabilities | sort:"position" %}
@@ -41,7 +41,7 @@ layout: default
                     {% endfor %}
                   </div>
                 </div>
-                
+
                 <div class="visible-md-block visible-lg-block">
                   <div class="row">
                     {% assign sorted_services = section.capabilities | sort:"position" %}
@@ -67,20 +67,38 @@ layout: default
                     {% endfor %}
                   </div>
                 </div>
-              
+
               </div>
             </div>
           </div>
+
         {% when "work" %}
           {% include featured-work.html %}
-          
+
         {% when "dribbble_feed" %}
           {% include dribbble-feed.html %}
+
+        {% when "concierge" %}
+          <div class="hero-capabilities">
+            <div class="row">
+              <div class="concierge-features">
+                {% assign sorted_features = section.features | sort:"position" %}
+                {% for feature in sorted_features %}
+                  <div class="capability-module">
+                    <div class="capability-graphic">
+                      <img src="{{ feature.image }}" />
+                    </div>
+                    <h2 class="capability-title">{{ feature.title }}</h2>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
 
       {% endcase %}
       <div class="section-footer">
         {{ section.footer_md | markdownify }}
-      </div>      
+      </div>
     </div>
   </section>
 {% endfor %}

--- a/_sass/pages/_homepage.scss
+++ b/_sass/pages/_homepage.scss
@@ -7,15 +7,15 @@
 .capability-module {
   position: relative;
   z-index: 1;
-  
+
   @include breakpoint(xs) {
     margin-bottom: 50px;
   }
-  
+
   @include breakpoint(sm) {
     margin-bottom: 50px;
   }
-  
+
   @include breakpoint(md) {
     margin-bottom: 0;
   }
@@ -29,12 +29,12 @@
   display: inline-block;
   height: 100px;
   width: 100px;
-  
+
   img {
     max-width: 100%;
     max-height: 100%;
   }
-  
+
   img[src="/uploads/capability-graphic-digital.png"] {
     margin-top: 11px;
     height: auto;
@@ -44,20 +44,20 @@
 .capability-detail {
   padding: 30px;
   list-style: none;
-  
+
   .row-eq-height & {
     margin-left: 15px;
     margin-right: 15px;
   }
-  
+
   @include breakpoint(xs) {
     margin-top: -12px;
   }
-  
+
   @include breakpoint(sm) {
     margin-top: -12px;
   }
-  
+
   @include breakpoint(md) {
     margin-top: -15px;
   }
@@ -66,9 +66,30 @@
     margin-bottom: 11px;
     font-size: 18px;
     line-height: 1.1;
-    
+
     &:last-child {
       margin-bottom: 0;
     }
   }
-  
+
+.concierge-features {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+
+  .capability-module {
+    padding: 0 25px 50px;
+
+    @include breakpoint(sm) {
+      flex: 1 0 100%;
+    }
+
+    @include breakpoint(md) {
+      flex: 0 0 50%;
+    }
+
+    @include breakpoint(lg) {
+      flex: 0 0 25%;
+    }
+  }
+}

--- a/homepage.markdown
+++ b/homepage.markdown
@@ -6,7 +6,7 @@ position: 0
 show_in_nav: false
 sections:
 - name: hero
-  bg_color_name: 
+  bg_color_name:
   title_md: |-
     <h1>
             <div>Good design means</div>
@@ -45,9 +45,9 @@ sections:
   footer_md: <h2><a href="/about" class="link link-blue">Learn more</a> about what
     we can do.</h2>
 - name: work
-  bg_color_name: 
-  title_md: 
-  content_md: 
+  bg_color_name:
+  title_md:
+  content_md:
   footer_md: <h2><a href="/work" class="link link-blue">Go to</a> all projects.</h2>
 - name: call_to_action
   bg_color_name: green-faded
@@ -56,7 +56,29 @@ sections:
     We’d love to talk with you about your next creative endeavor. Send us a note or give us a call and let’s start a new project together.
     {: .bigger .text-center }
   footer_md: <h2><a href="/contact" class="btn">Start a project</a></h2>
+- name: concierge
+  bg_color_name:
+  title_md: |-
+    <h1>
+            <div>Concierge title</div>
+            <div>
+              <a href="/about" class="link link-green">good business</a>.
+            </div>
+          </h1>
+  content_md: |-
+    We know that good design means
+    good business. We help our clients succeed by creating brand identities, digital experiences, and print materials that communicate clearly, achieve marketing goals, and look fantastic.
+    {: .bigger .text-center }
+  features:
+  - title: Nothing to learn, nothing to remember
+    image: "/uploads/capability-graphic-identity.png"
+  - title: A beautiful design in no time
+    image: "/uploads/capability-graphic-digital.png"
+  - title: All your updates, always up-to-date
+    image: "/uploads/capability-graphic-print.png"
+  - title: Features to propel your business
+    image: "/uploads/capability-graphic-identity.png"
+  footer_md: <h2><a href="/contact" class="btn">Start a project</a></h2>
 og_image: "/uploads/concentric_design_ogshare.png"
 layout: homepage
 ---
-


### PR DESCRIPTION
Creates a new section of homepage to showcase and link to Concierge site. Jeff will finalize content later in Siteleaf.

<img width="1413" alt="Screen Shot 2019-06-13 at 2 57 35 PM" src="https://user-images.githubusercontent.com/5250882/59463643-1f64aa80-8dec-11e9-916b-28da069c168a.png">
